### PR TITLE
Rename mini_typer as typer_core

### DIFF
--- a/src/rebar3_typer_prv.erl
+++ b/src/rebar3_typer_prv.erl
@@ -34,7 +34,7 @@ do(State) ->
         RebarConfigOpts = parse_rebar_config(State),
         Merged = maps:merge(RebarConfigOpts, CmdLineOpts),
         Opts = ensure_defaults(Merged, State),
-        ok = rebar3_mini_typer:run(Opts),
+        ok = typer_core:run(Opts),
         {ok, State}
     catch
         error:{unrecognized_opt, Opt} ->
@@ -109,11 +109,11 @@ split_string(String) ->
 %% have been merged, because if we set it in the CLI defaults,
 %% the config file can't override them. We need to only set them
 %% if they're not set in either place.
--spec ensure_defaults(map(), rebar_state:t()) -> rebar3_mini_typer:opts().
+-spec ensure_defaults(map(), rebar_state:t()) -> typer_core:opts().
 ensure_defaults(Opts, State) ->
     default_plt(default_src_dirs(default_io(default_mode_show(Opts)), State), State).
 
--spec default_io(rebar3_mini_typer:opts()) -> rebar3_mini_typer:opts().
+-spec default_io(typer_core:opts()) -> typer_core:opts().
 default_io(Opts) ->
     Opts#{io =>
               #{debug => fun rebar_api:debug/2,
@@ -121,13 +121,13 @@ default_io(Opts) ->
                 warn => fun rebar_api:warn/2,
                 abort => fun rebar_api:abort/2}}.
 
--spec default_mode_show(map()) -> rebar3_mini_typer:opts().
+-spec default_mode_show(map()) -> typer_core:opts().
 default_mode_show(#{mode := _Anything} = Opts) ->
     Opts;
 default_mode_show(Opts) ->
     Opts#{mode => show}.
 
--spec default_plt(map(), rebar_state:t()) -> rebar3_mini_typer:opts().
+-spec default_plt(map(), rebar_state:t()) -> typer_core:opts().
 default_plt(#{plt := _Anything} = Opts, _State) ->
     Opts;
 default_plt(#{} = Opts, State) ->
@@ -157,8 +157,7 @@ get_plt(State) ->
     Filename = Prefix ++ "_" ++ rebar_utils:otp_release() ++ "_plt",
     filename:join(Dir, Filename).
 
--spec default_src_dirs(rebar3_mini_typer:opts(), rebar_state:t()) ->
-                          rebar3_mini_typer:opts().
+-spec default_src_dirs(typer_core:opts(), rebar_state:t()) -> typer_core:opts().
 default_src_dirs(#{files_r := _Anything} = Opts, _State) ->
     Opts;
 default_src_dirs(#{files := _Anything} = Opts, _State) ->

--- a/src/typer_core.erl
+++ b/src/typer_core.erl
@@ -3,7 +3,7 @@
 %%%      annotate the code of files with such type information.
 %%%      This module is basically a carbon-copy of Erlang/OTP's typer,
 %%%      but built in a way that it can be executed not as a script.
--module(rebar3_mini_typer).
+-module(typer_core).
 
 -hank([{unnecessary_function_arguments, [swallow_output]}]).
 

--- a/test/rebar3_typer_prv_SUITE.erl
+++ b/test/rebar3_typer_prv_SUITE.erl
@@ -23,8 +23,8 @@ all() ->
 
 init_per_testcase(_, Config) ->
     Self = self(),
-    meck:new(rebar3_mini_typer),
-    meck:expect(rebar3_mini_typer,
+    meck:new(typer_core),
+    meck:expect(typer_core,
                 run,
                 fun(Opts) ->
                    Self ! #{opts => Opts},
@@ -33,7 +33,7 @@ init_per_testcase(_, Config) ->
     Config.
 
 end_per_testcase(_, Config) ->
-    meck:unload(rebar3_mini_typer),
+    meck:unload(typer_core),
     Config.
 
 %% @doc Just try to run typer without options

--- a/test/typer_core_SUITE.erl
+++ b/test/typer_core_SUITE.erl
@@ -1,5 +1,5 @@
-%%% @doc Test module for rebar3_mini_typer
--module(rebar3_mini_typer_SUITE).
+%%% @doc Test module for typer_core
+-module(typer_core_SUITE).
 
 -behaviour(ct_suite).
 
@@ -205,7 +205,7 @@ run_typer(Opts) ->
         #{plt => default_plt(),
           mode => show,
           io => default_io()},
-    try rebar3_mini_typer:run(
+    try typer_core:run(
             maps:merge(DefaultOpts, Opts))
     of
         ok ->


### PR DESCRIPTION
The very first step towards #15. Just a rename for now.